### PR TITLE
Switch to memmap2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ version = "0.1.2"
 edition = "2018"
 
 [dependencies]
-memmap = "0.7"
+memmap2 = "0.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ use std::io::ErrorKind;
 use std::io::{Error, Result};
 use std::ops::Range;
 
-use memmap::{Mmap, MmapOptions};
+use memmap2::{Mmap, MmapOptions};
 
 /// Four-character code
 pub type FourCC = [u8; 4];


### PR DESCRIPTION
memmap has an "unmaintained" [rustsec advisory](https://rustsec.org/advisories/RUSTSEC-2020-0077). I don't know of a reason to switch beyond that.