### PR TITLE
Allow opening with a File in addition to a filename

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![doc = include_str!("../README.md")]
 
-use std::fs;
 use std::fs::File;
 use std::io::ErrorKind;
 use std::io::{Error, Result};
@@ -65,10 +64,14 @@ pub struct RiffFile {
 
 /// Resource Interchange File Format
 impl RiffFile {
-    /// Open a RIFF file
+    /// Open a RIFF file from a filename
     pub fn open(filename: &str) -> Result<Self> {
         let file = File::open(&filename)?;
-        let metadata = fs::metadata(&filename)?;
+        Self::open_with_file_handle(&file)
+    }
+    /// Open a RIFF file from a `File` handle
+    pub fn open_with_file_handle(file: &File) -> Result<Self> {
+        let metadata = file.metadata()?;
         let len = metadata.len() as usize;
         let mmap = unsafe { MmapOptions::new().map(&file)? };
 


### PR DESCRIPTION
This is useful if the caller has been given a `File` but not a filename, which can happen in the case of an audio utility that was given a set of search paths for a resource (e.g., a given sample could be on this drive, or that drive, or that drive over there), and the search functionality returns a `File` handle but not the constructed path where it found the file.